### PR TITLE
fix: release.yml workflow failing because the cli is not found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies 👨🏻‍💻
-        run: pnpm install --prod
+        run: pnpm install --prod=false
 
       - name: Build all packages 📦
         run: pnpm -r build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies 👨🏻‍💻
-        run: pnpm install
+        run: pnpm install --prod
 
       - name: Build all packages 📦
         run: pnpm -r build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies 👨🏻‍💻
-        run: pnpm install --prod
+        run: pnpm install --prod=false
 
       - name: Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies 👨🏻‍💻
-        run: pnpm install
+        run: pnpm install --prod
 
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
+        run: pnpm semantic-release

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "concurrently": "^8.2.2",
     "eslint": "^9.8.0",
     "prettier": "^3.3.3",
+    "semantic-release": "^24.0.0",
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.0.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
+      semantic-release:
+        specifier: ^24.0.0
+        version: 24.0.0(typescript@5.5.4)
       typescript:
         specifier: ^5.5.4
         version: 5.5.4


### PR DESCRIPTION
Attempt to fix the _release.yml_ workflow that failed:
https://github.com/accesimpot/graphql-lookahead/actions/runs/10387100789/job/28759843259

<img width="892" alt="image" src="https://github.com/user-attachments/assets/96ab8e4b-1293-4024-87ae-246c24735f71">

### What

- Enforce installing `devDependencies` with `--prod=false` in _ci.yml_ and _release.yml_ workflows
