### PR TITLE
fix: impossible to install on other Node version than 20.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "20.16.0"
+    "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
   },
   "scripts": {
     "build": "pnpm -F=main build",


### PR DESCRIPTION
The Node version enforced in package.json was very specific to `20.16.0` making it impossible to install on any other version.

Since the `graphql` package is the only dependency, I re-used their version ranges: 
https://github.com/graphql/graphql-js/blob/9a91e338101b94fb1cc5669dd00e1ba15e0f21b3/package.json#L29-L31