### PR TITLE
fix: support for FragmentSpread selection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout branch 🛎
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.CI_GITHUB_TOKEN }}
+          persist-credentials: false
           fetch-depth: 0
 
       # https://nx.dev/packages/nx/documents/affected

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ export const resolvers: Resolver = {
 import type { GraphQLResolveInfo, SelectionSetNode } from 'graphql'
 
 function lookahead<TState>(options: {
-  info: Pick<GraphQLResolveInfo, 'operation' | 'schema' | 'returnType' | 'path'>
+  info: Pick<GraphQLResolveInfo, 'operation' | 'schema' | 'fragments' | 'returnType' | 'path'>
   next?: (details: HandlerDetails<TState>) => TState
   state?: TState
   until?: (details: HandlerDetails<TState>) => boolean
@@ -100,7 +100,7 @@ function lookahead<TState>(options: {
 
 type HandlerDetails<TState> = {
   field: string
-  selectionSet: SelectionSetNode
+  selection: SelectionNode
   state: TState
   type: string
 }

--- a/packages/playground/src/graphql-yoga/graphql-yoga.spec.ts
+++ b/packages/playground/src/graphql-yoga/graphql-yoga.spec.ts
@@ -62,17 +62,20 @@ describe('graphql-yoga', () => {
     })
   })
 
-  describe('when it sends cart query and a query with inline fragment', async () => {
+  describe('when it sends full cart query and product page query with alias and fragments', async () => {
     describe('when lookahead is called within non-Query resolver', async () => {
       const result = await execute({
         document: getFixtureQuery('graphql-yoga/queries/cart-and-page.gql'),
       })
 
-      it('returns partial cart data', () => {
-        expect(result.data).toEqual({ order: mockFullCart, page: mockPage })
+      it('returns full cart data with alias', () => {
+        expect(result.data).toEqual({
+          order: getMockFullCartWithProductGroupAlias(),
+          page: mockPage,
+        })
       })
 
-      it('has only the deepest query filter in meta data', () => {
+      it('has only the deepest query filter in ProductPageContent meta data', () => {
         expect(
           result.extensions?.meta?.['ProductPageContent.products'].sequelizeQueryFilters
         ).toEqual({ include: [{ model: 'Inventory' }] })
@@ -88,6 +91,21 @@ function getMockPartialCart() {
     const itemCopy = { ...item }
     // @ts-expect-error Not relevant in test
     delete itemCopy.product
+    items.push(itemCopy)
+  })
+
+  return { ...mockFullCart, items }
+}
+
+function getMockFullCartWithProductGroupAlias() {
+  const items = [] as (typeof mockFullCart)['items']
+
+  mockFullCart.items.forEach(item => {
+    const itemCopy = { ...item }
+    // @ts-expect-error Not relevant in test
+    itemCopy.group = itemCopy.productGroup
+    // @ts-expect-error Not relevant in test
+    delete itemCopy.productGroup
     items.push(itemCopy)
   })
 

--- a/packages/playground/src/graphql-yoga/queries/cart-and-page.gql
+++ b/packages/playground/src/graphql-yoga/queries/cart-and-page.gql
@@ -9,17 +9,10 @@ query cart {
       quantity
 
       product {
-        __typename
-        id
-        color
-        size
-        inventory {
-          __typename
-          stock
-        }
+        ...ProductFragment
       }
 
-      productGroup {
+      group: productGroup {
         __typename
         name
         categories
@@ -38,17 +31,20 @@ query cart {
 
       ... on ProductPageContent {
         products {
-          __typename
-          id
-          color
-          size
-
-          inventory {
-            __typename
-            stock
-          }
+          ...ProductFragment
         }
       }
     }
+  }
+}
+
+fragment ProductFragment on Product {
+  __typename
+  id
+  color
+  size
+  inventory {
+    __typename
+    stock
   }
 }


### PR DESCRIPTION
As mentioned in https://github.com/accesimpot/graphql-lookahead/pull/1

> - `lookahead` doesn't go through named fragments (`...ProductFragment`). It only works with inline fragments (`... on ProductPageContent`)

This PR fixes the issue and cover it in integration tests.