### PR TITLE
fix: wrong initial selectionSet when fragments are present in operation

### DIFF
--- a/packages/graphql-lookahead/src/utils/generic.ts
+++ b/packages/graphql-lookahead/src/utils/generic.ts
@@ -1,6 +1,142 @@
 import type { GraphQLType, GraphQLResolveInfo, SelectionSetNode, SelectionNode } from 'graphql'
 
 /**
+ * Given the info.path representing the location in the operation from where the resolver was
+ * triggered, the function finds the selectionSet that matches that path.
+ */
+export function findSelectionSetForInfoPath(
+  info: Pick<GraphQLResolveInfo, 'schema' | 'fragments' | 'path'> & {
+    operation: Pick<GraphQLResolveInfo['operation'], 'selectionSet'>
+  }
+) {
+  return findSelectionSetForPathArray({
+    info,
+    paths: pathToArray(info.path),
+    pathIndex: 0,
+    selectionSet: info.operation.selectionSet,
+  })
+}
+
+function findSelectionSetForPathArray(options: {
+  info: Pick<GraphQLResolveInfo, 'schema' | 'fragments'>
+  paths: ReturnType<typeof pathToArray>
+  pathIndex: number
+  selectionSet: SelectionSetNode
+}) {
+  const currentSelectionPath: (typeof options.paths)[0] = options.paths[options.pathIndex]
+  if (!currentSelectionPath) return
+
+  const selectionSet = options.selectionSet
+
+  let selectionMatch: (typeof selectionSet.selections)[0] | undefined
+  let nextSelectionSetMatch: SelectionSetNode | undefined
+  let nextPathIndexAddition = 1
+
+  const findByName = (select: SelectionNode) => {
+    if ('name' in select && select.name.value === currentSelectionPath.key) return select
+  }
+
+  for (const selection of selectionSet.selections) {
+    const selectionName = findSelectionName(selection)
+
+    // This should only happen if the selection is invalid
+    if (!selectionName) continue
+
+    const { isFragmentSelection, nextSelectionSet, selectionTypeName } = getSelectionDetails({
+      info: options.info,
+      selection,
+      selectionName,
+      type: currentSelectionPath.typename,
+    })
+
+    if (isFragmentSelection && selectionTypeName === currentSelectionPath.typename) {
+      nextPathIndexAddition = 0
+
+      if (nextSelectionSet && selection.kind === 'FragmentSpread') {
+        selectionMatch = nextSelectionSet.selections.find(findByName)
+      }
+      if (selection.kind === 'InlineFragment') selectionMatch = selection
+    }
+    if (!isFragmentSelection) selectionMatch = findByName(selection)
+
+    if (selectionMatch) {
+      if (nextSelectionSet) nextSelectionSetMatch = nextSelectionSet
+      break
+    }
+  }
+
+  if (!nextSelectionSetMatch) return
+
+  const nextPathIndex = options.pathIndex + nextPathIndexAddition
+  if (nextPathIndex === options.paths.length) return nextSelectionSetMatch
+
+  return findSelectionSetForPathArray({
+    info: options.info,
+    paths: options.paths,
+    pathIndex: options.pathIndex + nextPathIndexAddition,
+    selectionSet: nextSelectionSetMatch,
+  })
+}
+
+export function getSelectionDetails(options: {
+  info: Pick<GraphQLResolveInfo, 'schema' | 'fragments'>
+  selection: SelectionNode
+  selectionName: string
+  type?: string
+}) {
+  const { info, selection, selectionName, type } = options
+
+  let isFragmentSelection = false
+  let nextSelectionSet: SelectionSetNode | undefined
+  let selectionTypeName: string | undefined
+
+  if (selection.kind === 'FragmentSpread') {
+    isFragmentSelection = true
+
+    const fragmentDefinition = info.fragments[selectionName]
+    selectionTypeName = fragmentDefinition.typeCondition.name.value
+    nextSelectionSet = fragmentDefinition.selectionSet
+  } else {
+    if ('selectionSet' in selection && selection.selectionSet) {
+      nextSelectionSet = selection.selectionSet
+    }
+    if (selection.kind === 'InlineFragment') {
+      isFragmentSelection = true
+      selectionTypeName = selection.typeCondition?.name.value
+    } else if (type) {
+      const childFields = getChildFields(info.schema, type)
+
+      if (childFields && selectionName in childFields) {
+        selectionTypeName = findTypeName(childFields[selectionName].type)
+      }
+    }
+  }
+  return { isFragmentSelection, nextSelectionSet, selectionTypeName }
+}
+
+/**
+ * Given a Path (taken from the resolver argument info.path), it returns an array of the path
+ * object in the right order (from the query field to the most nested field).
+ *
+ * Inspired by `pathToArray` from 'graphql', but instead of returning only an array of key string,
+ * it returns the object including both the "key" and the "typename". It also filters out the paths
+ * with a key of type number (only relevant for retrieving the path in the data, not in the
+ * operation selection).
+ *
+ * @see https://github.com/graphql/graphql-js/blob/9a91e338101b94fb1cc5669dd00e1ba15e0f21b3/src/jsutils/Path.ts#L23
+ */
+export function pathToArray(path: GraphQLResolveInfo['path'] | undefined) {
+  const flattened = []
+  let prev = path
+
+  while (prev) {
+    if (typeof prev.key === 'string') flattened.push({ key: prev.key, typename: prev.typename })
+    prev = prev.prev
+  }
+  return flattened.reverse()
+}
+
+/**
  * Returns the child fields of a given type based on its definition in the schema.
  */
 export function getChildFields(
@@ -53,87 +189,4 @@ export function findSelectionName(selection: SelectionNode) {
   if (!selectionNameObj || !('name' in selectionNameObj)) return
 
   return selectionNameObj.name.value
-}
-
-/**
- * Given the info.path representing the location in the operation from where the resolver was
- * triggered, the function finds the selectionSet that matches that path.
- */
-export function findSelectionSetForInfoPath(
-  info: Pick<GraphQLResolveInfo, 'path'> & {
-    operation: Pick<GraphQLResolveInfo['operation'], 'selectionSet'>
-  }
-) {
-  return findSelectionSetForPathArray({
-    paths: pathToArray(info.path),
-    pathIndex: 0,
-    selectionSet: info.operation.selectionSet,
-  })
-}
-
-function findSelectionSetForPathArray(options: {
-  paths: ReturnType<typeof pathToArray>
-  pathIndex: number
-  selectionSet: SelectionSetNode
-}) {
-  const currentSelectionPath: (typeof options.paths)[0] | undefined =
-    options.paths[options.pathIndex]
-  if (!currentSelectionPath) return options.selectionSet
-
-  const selectionSet = options.selectionSet
-
-  let currentSelection: (typeof selectionSet.selections)[0] | undefined
-
-  if (typeof currentSelectionPath.key === 'number') {
-    currentSelection = selectionSet.selections[currentSelectionPath.key]
-  } else {
-    const findByName = (select: SelectionNode) => {
-      if ('name' in select && select.name.value === currentSelectionPath.key) return select
-    }
-    for (const selection of selectionSet.selections) {
-      currentSelection = findByName(selection)
-
-      if (currentSelection) break
-      else if (
-        'typeCondition' in selection &&
-        selection.typeCondition?.name.value === currentSelectionPath.typename
-      ) {
-        currentSelection = selection.selectionSet.selections.find(findByName)
-      }
-    }
-  }
-
-  if (!currentSelection || !('selectionSet' in currentSelection)) return
-
-  if (currentSelection.selectionSet) {
-    if (options.pathIndex >= options.paths.length) return currentSelection.selectionSet
-
-    return findSelectionSetForPathArray({
-      paths: options.paths,
-      pathIndex: options.pathIndex + 1,
-      selectionSet: currentSelection.selectionSet,
-    })
-  }
-}
-
-/**
- * Given a Path (taken from the resolver argument info.path), it returns an array of the path
- * object in the right order (from the query field to the most nested field).
- *
- * Inspired by `pathToArray` from 'graphql', but instead of returning only an array of key string,
- * it returns the object including both the "key" and the "typename".
- *
- * @see https://github.com/graphql/graphql-js/blob/9a91e338101b94fb1cc5669dd00e1ba15e0f21b3/src/jsutils/Path.ts#L23
- */
-export function pathToArray(
-  path: GraphQLResolveInfo['path'] | undefined
-): GraphQLResolveInfo['path'][] {
-  const flattened = []
-  let prev = path
-
-  while (prev) {
-    flattened.push(prev)
-    prev = prev.prev
-  }
-  return flattened.reverse()
 }


### PR DESCRIPTION
Lookahead was working fine for resolver defined on Query fields, but it wasn't retrieving the right initial `selectionSet` when the resolver was on non-Query fields and including a fragment.

This PR fixes it. Will add integration tests in a follow-up PR.