### PR TITLE
docs(README): add missing depth and onError options in README "Types" section

### DIFF
--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -16,3 +16,4 @@ jobs:
           scopes: |
             deps
             deps-dev
+            README

--- a/README.md
+++ b/README.md
@@ -91,9 +91,11 @@ export const resolvers: Resolver = {
 ```ts
 import type { GraphQLResolveInfo, SelectionSetNode } from 'graphql'
 
-function lookahead<TState>(options: {
+function lookahead<TState, RError extends boolean | undefined>(options: {
+  depth?: number | null
   info: Pick<GraphQLResolveInfo, 'operation' | 'schema' | 'fragments' | 'returnType' | 'path'>
   next?: (details: HandlerDetails<TState>) => TState
+  onError?: (err: unknown) => RError
   state?: TState
   until?: (details: HandlerDetails<TState>) => boolean
 }): boolean
@@ -231,6 +233,9 @@ Visit the playground at http://localhost:4455/graphql 🚀
 
   # Run Vitest
   pnpm test
+
+  # Run Vitest in watch mode
+  pnpm test:watch
   ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ type HandlerDetails<TState> = {
 
 | Name | Description |
 | ------ | :---------- |
-| `depth` | ❔ _Optional_ - Specify how deep it should look in the `selectionSet` (i.e. `depth: 1` is the initial `selectionSet`, `depth: null` is no limit). |
+| `depth` | ❔ _Optional_ - Specify how deep it should look in the `selectionSet` (i.e. `depth: 1` is the initial `selectionSet`, `depth: null` is no limit). Default: `depth: null`. |
 | `info` | ❗️ _Required_ - GraphQLResolveInfo object which is usually the fourth argument of the resolver function. |
 | `next` | ❔ _Optional_ - Handler called for every nested field within the operation. It can return a state that will be passed to each `next` call of its direct child fields. See [Advanced usage](#advanced-usage). |
 | `onError` | ❔ _Optional_ - Hook called from a `try..catch` when an error is caught. Default: `(err: unknown) => { console.error(ERROR_PREFIX, err); return true }`. |

--- a/packages/graphql-lookahead/src/utils/main.ts
+++ b/packages/graphql-lookahead/src/utils/main.ts
@@ -20,7 +20,7 @@ type HandlerDetails<TState> = {
  * operation (`info.operation`). This allows you to avoid querying nested database relationships
  * if they are not requested.
  *
- * @param options.depth - Specify how deep it should look in the `selectionSet` (i.e. `depth: 1` is the initial `selectionSet`, `depth: null` is no limit).
+ * @param options.depth - Specify how deep it should look in the `selectionSet` (i.e. `depth: 1` is the initial `selectionSet`, `depth: null` is no limit). Default: `depth: null`.
  * @param options.info - GraphQLResolveInfo object which is usually the fourth argument of the resolver function.
  * @param options.next - Handler called for every nested field within the operation. It can return a state that will be passed to each `next` call of its direct child fields. See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
  * @param options.onError - Hook called from a `try..catch` when an error is caught. Default: `(err: unknown) => { console.error(ERROR_PREFIX, err); return true }`.
@@ -95,7 +95,7 @@ export function lookaheadAndThrow<TState, RError extends boolean | undefined>(op
  * @type TState - Initial state used in `next` handler.
  * @type RError -
  *
- * @param options.depth - Specify how deep it should look in the `selectionSet` (i.e. `depth: 1` is the initial `selectionSet`, `depth: null` is no limit).
+ * @param options.depth - Specify how deep it should look in the `selectionSet` (i.e. `depth: 1` is the initial `selectionSet`, `depth: null` is no limit). Default: `depth: null`.
  * @param options.next - Handler called for every nested field within the operation. It can return a state that will be passed to each `next` call of its direct child fields. See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
  * @param options.onError - Hook called from a `try..catch` when an error is caught. Default: `(err: unknown) => { console.error(ERROR_PREFIX, err); return true }`.
  * @param options.schema - GraphQLResolveInfo['schema'] object


### PR DESCRIPTION
The options `depth` and `onError` were missing in the `Types` section of the README.