### PR TITLE
fix: use onError return value for all error cases

### DIFF
--- a/packages/graphql-lookahead/src/utils/main.ts
+++ b/packages/graphql-lookahead/src/utils/main.ts
@@ -6,7 +6,7 @@ import {
   findSelectionSetForInfoPath,
 } from './generic'
 
-const ERROR_PREFIX = 'ERROR [graphql-lookahead]: '
+const ERROR_PREFIX = '[graphql-lookahead]'
 
 type HandlerDetails<TState> = {
   field: string
@@ -69,7 +69,7 @@ export function lookaheadAndThrow<TState, RError extends boolean | undefined>(op
   const state = options.state as TState
 
   const returnTypeName = findTypeName(info.returnType)
-  if (!returnTypeName) return true
+  if (!returnTypeName) throw new Error('Invalid `info.returnType`.')
 
   const selectionSet = findSelectionSetForInfoPath(info)
 
@@ -85,7 +85,7 @@ export function lookaheadAndThrow<TState, RError extends boolean | undefined>(op
       until: options.until,
     })
   }
-  return true
+  throw new Error('No `selectionSet` found for the given `info.path`.')
 }
 
 /**

--- a/packages/playground/src/graphql-yoga/graphql-yoga.spec.ts
+++ b/packages/playground/src/graphql-yoga/graphql-yoga.spec.ts
@@ -27,7 +27,7 @@ describe('graphql-yoga', () => {
     })
 
     it('returns full cart data', () => {
-      expect(result.data).toEqual({ order: mockFullCart })
+      expect(result.data).toEqual({ order: { ...mockFullCart, invalidField: null } })
     })
 
     it('has "hasQuantityFieldDepthOne" set to false in meta data', () => {

--- a/packages/playground/src/graphql-yoga/queries/full-cart.gql
+++ b/packages/playground/src/graphql-yoga/queries/full-cart.gql
@@ -28,5 +28,8 @@ query fullCart {
     tax
     subtotal
     total
+
+    # to cover the invalid cases
+    invalidField
   }
 }

--- a/packages/playground/src/graphql-yoga/testUtils.ts
+++ b/packages/playground/src/graphql-yoga/testUtils.ts
@@ -4,6 +4,8 @@ import cloneDeep from 'lodash.clonedeep'
 import { lookahead } from '../../../graphql-lookahead/src'
 
 export function callInvalidLookaheads(info: GraphQLResolveInfo) {
+  if (!lookahead({ info, until: ({ field }) => field === 'invalidField' })) return
+
   // @ts-expect-error test invalid `next` option
   const invalidNext = lookahead({ info, next: 5 }) // returns true
 

--- a/packages/playground/src/schema.gql
+++ b/packages/playground/src/schema.gql
@@ -9,6 +9,7 @@ type Order {
   tax: Int!
   subtotal: Int!
   total: Int!
+  invalidField: String
 }
 
 type Inventory {


### PR DESCRIPTION
### What

- Fix returning onError value for all error cases
  - If `onError` is provided and return false, we have to return false in all error cases which wasn't the case in two places. We now throw an error in those two cases so that it is picked up by the parent catch block.
- Log errors only when "invalidField" is requested
  - Otherwise, it can be noisy and confusing in the playground