### PR TITLE
fix: trigger release for previous PR updating repository url

### DIFF
--- a/packages/graphql-lookahead/src/index.ts
+++ b/packages/graphql-lookahead/src/index.ts
@@ -1,1 +1,2 @@
+// Make all main utils public
 export * from './utils/main'


### PR DESCRIPTION
https://github.com/accesimpot/graphql-lookahead/pull/25 should have triggered a release, but it was [skipped](https://github.com/accesimpot/graphql-lookahead/actions/runs/10470927874/job/28997105677) because no changes were detected in the main package:

<img width="805" alt="image" src="https://github.com/user-attachments/assets/a06e9089-6ef0-4c8d-9cdc-78c93b9aedc5">

Add a dummy comment in the main package for now so it forces the release. Will follow-up with a proper fix.