### PR TITLE
fix: trigger release workflow on readme change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,11 +45,12 @@ jobs:
         # Make sure the job fails with exit code 1 if the nx command fails
         run: |
           projects=$(pnpm --silent nx show projects --projects main --affected || echo 'error')
-          [ "$projects" == 'error' ] && exit 1
+          projects+=$(git diff --name-only --diff-filter=d ${{ steps.setSHAs.outputs.base }} -- README.md || echo 'error')
 
-          array=($projects)
+          projects_array=($projects)
+          [[ ${projects_array[*]} =~ 'error' ]] && exit 1
 
-          echo "count=${#array[@]}" >> $GITHUB_OUTPUT
+          echo "count=${#projects_array[@]}" >> $GITHUB_OUTPUT
 
       - name: Build main package 📦
         if: steps.main-package-affected.outputs.count > 0


### PR DESCRIPTION
Release workflow was not triggered if there was no change affecting the main package so it wasn't triggered on README change only. This PR makes sure that the release workflow is triggered on README change as well.