### PR TITLE
fix: trigger release for previous PR updating typo in README

### DIFF
--- a/packages/graphql-lookahead/src/index.ts
+++ b/packages/graphql-lookahead/src/index.ts
@@ -1,2 +1,1 @@
-// Make all main utils public
 export * from './utils/main'


### PR DESCRIPTION
See
- [docs(README): fix wrong type imported from graphql in README](https://github.com/accesimpot/graphql-lookahead/pull/28)
- [fix: trigger release workflow on readme change](https://github.com/accesimpot/graphql-lookahead/pull/29)

This PR simply removes a dummy comment to make the workflow detect changes in the main package and trigger a release (should now be fixed for next time).