### PR TITLE
refactor: remove findSelectionSetForInfoPath utility in favor of info.fieldNodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,10 @@ import type { GraphQLResolveInfo, SelectionNode } from 'graphql'
 
 function lookahead<TState, RError extends boolean | undefined>(options: {
   depth?: number | null
-  info: Pick<GraphQLResolveInfo, 'operation' | 'schema' | 'fragments' | 'returnType' | 'path'>
+  info: Pick<
+    GraphQLResolveInfo,
+    'operation' | 'schema' | 'fragments' | 'returnType' | 'fieldNodes' | 'fieldName'
+  >
   next?: (details: HandlerDetails<TState>) => TState
   onError?: (err: unknown) => RError
   state?: TState

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
   },
   "scripts": {
-    "dev": "NODE_ENV=development concurrently --kill-others -p=none \"pnpm main dev\" \"pnpm playground dev\"",
+    "dev": "NODE_ENV=development concurrently --kill-others -p=none \"pnpm main: dev\" \"pnpm playground: dev\"",
     "build": "nx run-many -t build",
     "lint": "pnpm lint:all",
     "lint:fix": "pnpm lint:all:fix",
@@ -33,7 +33,9 @@
     "test:watch": "vitest",
     "dev-utils": "bash -c 'nx ${0} dev-utils $@'",
     "main": "bash -c 'nx ${0} main $@'",
-    "playground": "bash -c 'nx ${0} playground $@'"
+    "main:": "pnpm -F=main",
+    "playground": "bash -c 'nx ${0} playground $@'",
+    "playground:": "pnpm -F=playground"
   },
   "exports": {
     ".": {

--- a/packages/playground/src/graphql-yoga/queries/cart-and-page.gql
+++ b/packages/playground/src/graphql-yoga/queries/cart-and-page.gql
@@ -31,14 +31,16 @@ query cart {
 
       ... on ProductPageContent {
         products {
-          __typename
-          id
-          color
-          size
-          inventory {
+          ... on Product {
             __typename
             id
-            stock
+            color
+            size
+            inventory {
+              __typename
+              id
+              stock
+            }
           }
         }
       }

--- a/packages/playground/src/graphql-yoga/testUtils.ts
+++ b/packages/playground/src/graphql-yoga/testUtils.ts
@@ -38,8 +38,8 @@ export function callInvalidOrderLookaheads(info: GraphQLResolveInfo) {
   }) // returns true
 
   const invalidInfoAndOnErrorReturningFalse = lookahead({
-    // @ts-expect-error test invalid `info`
-    info: undefined,
+    // @ts-expect-error invalid `info` throwing when no `selectionSet` is found in `info.fieldNodes`
+    info: { returnType: info.returnType, fieldNodes: [] },
     onError: () => false,
     until: ({ field }) => field === 'total',
   }) // returns false

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,8 +11,8 @@ export default defineConfig({
       include: ['packages/graphql-lookahead/src/**'],
 
       thresholds: {
-        statements: 94,
-        branches: 84,
+        statements: 95,
+        branches: 88,
         functions: 100,
         lines: 100,
       },


### PR DESCRIPTION
- Reduce amount of code by replacing `findSelectionSetForInfoPath` with built-in `info.fieldNodes`
- Fix manually killing process with CTRL+C in `dev` script