### PR TITLE
feat: allow importing generic utils from /utils path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,13 @@ jobs:
         if: steps.main-package-affected.outputs.count > 0
         run: pnpm main build
 
-      # A release is made if the prefix is feat, fix or perf
+      # A release is made if the prefix is feat, fix, perf, chore(deps), or docs(README)
+      #
+      # { type: 'feat', release: 'minor' },
+      # { type: 'fix', release: 'patch' },
+      # { type: 'perf', release: 'patch' },
+      # { type: 'chore', scope: 'deps', release: 'patch' },
+      # { type: 'docs', scope: 'README', release: 'patch' },
       #
       # See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular#type
       #

--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
     ".": {
       "import": "./packages/graphql-lookahead/dist/index.js",
       "require": "./packages/graphql-lookahead/dist/index.cjs"
+    },
+    "./utils": {
+      "import": "./packages/graphql-lookahead/dist/utils/generic.js",
+      "require": "./packages/graphql-lookahead/dist/utils/generic.cjs"
     }
   },
   "types": "./packages/graphql-lookahead/dist/index.d.ts",


### PR DESCRIPTION
- Add export path for generic utils in package.json
- Document release types for conventional commits
