### PR TITLE
fix: graphql module not set as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
   "files": [
     "packages/graphql-lookahead/dist"
   ],
+  "peerDependencies": {
+    "graphql": "16.x"
+  },
   "devDependencies": {
     "@eslint/compat": "^1.2.3",
     "@eslint/js": "^9.15.0",
@@ -86,9 +89,6 @@
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.15.0",
     "vitest": "^2.1.5"
-  },
-  "resolutions": {
-    "graphql": "^16.9.0"
   },
   "bugs": {
     "url": "https://github.com/accesimpot/graphql-lookahead/issues"

--- a/packages/graphql-lookahead/package.json
+++ b/packages/graphql-lookahead/package.json
@@ -8,6 +8,9 @@
     "build": "NODE_ENV=${NODE_ENV:-development} vite build",
     "types:check": "tsc --project tsconfig.lint.json"
   },
+  "peerDependencies": {
+    "graphql": "16.x"
+  },
   "devDependencies": {
     "@types/node": "^20.14.15",
     "dev-utils": "workspace:*",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -12,6 +12,9 @@
   "imports": {
     "#src/*": "./src/*"
   },
+  "peerDependencies": {
+    "graphql": "16.x"
+  },
   "devDependencies": {
     "@types/node": "^20.14.15",
     "concurrently": "^9.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  graphql: ^16.9.0
-
 importers:
 
   .:
@@ -97,6 +94,10 @@ importers:
         version: 4.3.0(@types/node@20.17.7)(rollup@4.27.4)(typescript@5.7.2)(vite@5.4.11(@types/node@20.17.7))
 
   packages/graphql-lookahead:
+    dependencies:
+      graphql:
+        specifier: 16.x
+        version: 16.9.0
     devDependencies:
       '@types/node':
         specifier: ^20.14.15
@@ -112,6 +113,10 @@ importers:
         version: 5.4.11(@types/node@20.17.7)
 
   packages/playground:
+    dependencies:
+      graphql:
+        specifier: 16.x
+        version: 16.9.0
     devDependencies:
       '@types/node':
         specifier: ^20.14.15
@@ -413,36 +418,36 @@ packages:
     resolution: {integrity: sha512-dJRj78QEGNNnlhkhqPUG9z+1uAr7znZ4dzabEVgY5uSXTmUIFcTKpOGYv2/QAuvyqGN40XxbcdVRJta6XHX2BQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^16.9.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
   '@graphql-tools/executor@1.3.4':
     resolution: {integrity: sha512-2XbOp1K8iQiDgExbBTrhjqQX1bh5lHbri3nEaL8pCiiirZTLs4C1a1mizGcQzkeciF41paWEfBu1M1mOewtFAQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^16.9.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
   '@graphql-tools/merge@9.0.10':
     resolution: {integrity: sha512-sU+b6ZmKtGnqHq8S+VI5UmjZVHWzT+b+QtCsJUEXckCKdq1P3JmwIT8+8DVxSQlh1dzpiVq37EOcJrEYOBZtBA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^16.9.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
   '@graphql-tools/schema@10.0.9':
     resolution: {integrity: sha512-R/sPRLJnEHg/F7owvH1zLbfXxqrEgFyr/qSjsG1q+gWhCrxbo/+c2DVjeZEZ2/AKCLllDHTD5TOU2Y5sZGNxZg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^16.9.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
   '@graphql-tools/utils@10.6.0':
     resolution: {integrity: sha512-bqSn2ekSNwFVZprY6YsrHkqPA7cPLNKxiPlEzS1djhfvx4q9tx7Uwc5dnLp3SSnKinJ8dJk9FA5sxNcKjCM44w==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      graphql: ^16.9.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
   '@graphql-typed-document-node/core@3.2.0':
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
-      graphql: ^16.9.0
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
   '@graphql-yoga/logger@2.0.0':
     resolution: {integrity: sha512-Mg8psdkAp+YTG1OGmvU+xa6xpsAmSir0hhr3yFYPyLNwzUj95DdIwsMpKadDj9xDpYgJcH3Hp/4JMal9DhQimA==}
@@ -1725,7 +1730,7 @@ packages:
     resolution: {integrity: sha512-TE6tFvWvD6LHy1v0hleEnftla5Oo2plgat/r8yHcUSS0Qqb+5fb/eHlthNAi+81gFziHc1mUE5w8PqMjBL5/eA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      graphql: ^16.9.0
+      graphql: ^15.2.0 || ^16.0.0
 
   graphql@16.9.0:
     resolution: {integrity: sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,11 @@
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  /**
+   * @see https://github.com/vitest-dev/vitest/issues/4605#issuecomment-1847658160
+   */
+  resolve: { alias: { graphql: 'graphql/index.js' } },
+
   test: {
     include: ['**/*.spec.ts'],
     globalSetup: 'vitest.setup.ts',


### PR DESCRIPTION
Now that we use an actual utility from the `graphql` module (`getArgumentValues`) and not only types, `graphql` should be added as a peer dependency.

Also fixes the issue in Vitest regarding multiple `graphql` versions used.