### PR TITLE
feat: add hook to run after all selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ type NextHandlerDetails<TState> = HandlerDetails<TState> & {
 | ------ | :---------- |
 | `depth` | ❔ _Optional_ - Specify how deep it should look in the `selectionSet` (i.e. `depth: 1` is the initial `selectionSet`, `depth: null` is no limit). Default: `depth: null`. |
 | `info` | ❗️ _Required_ - GraphQLResolveInfo object which is usually the fourth argument of the resolver function. |
-| `next` | ❔ _Optional_ - Handler called for every nested field within the operation. It can return a state that will be passed to each `next` call of its direct child fields. See [Advanced usage](#advanced-usage). |
+| `next` | ❔ _Optional_ - Handler called for every field with subfields within the operation. It can return a state that will be passed to each `next` call of its direct child fields. See [Advanced usage](#advanced-usage). |
 | `onError` | ❔ _Optional_ - Hook called from a `try..catch` when an error is caught. Default: `(err: unknown) => { console.error(ERROR_PREFIX, err); return true }`. |
 | `state` | ❔ _Optional_ - Initial state used in `next` handler. See [Advanced usage](#advanced-usage).|
 | `until` | ❔ _Optional_ - Handler called for every nested field within the operation. Returning true will stop the iteration and make `lookahead` return true as well. |

--- a/packages/playground/src/graphql-yoga/graphql-yoga.spec.ts
+++ b/packages/playground/src/graphql-yoga/graphql-yoga.spec.ts
@@ -42,6 +42,13 @@ describe('graphql-yoga', () => {
       )
     })
 
+    it('has "afterAllSelections" set to Product/color in meta data', () => {
+      expect(result.extensions?.meta?.afterAllSelections).toEqual({
+        sourceType: 'Product',
+        field: 'color',
+      })
+    })
+
     it('has "invalidNext" set to true in meta data', () => {
       expect(result.extensions?.meta?.['Query.order'].returnValue.invalidNext).toBe(true)
     })

--- a/packages/playground/src/graphql-yoga/graphql-yoga.spec.ts
+++ b/packages/playground/src/graphql-yoga/graphql-yoga.spec.ts
@@ -42,11 +42,12 @@ describe('graphql-yoga', () => {
       )
     })
 
-    it('has "afterAllSelections" set to Product/color in meta data', () => {
-      expect(result.extensions?.meta?.afterAllSelections).toEqual({
+    it('has "afterAllSelections" set to Product/color only once in meta data', () => {
+      expect(result.extensions?.meta?.afterAllSelections?.[0]).toEqual({
         sourceType: 'Product',
         field: 'color',
       })
+      expect(result.extensions?.meta?.afterAllSelections?.length).toBe(1)
     })
 
     it('has "invalidNext" set to true in meta data', () => {

--- a/packages/playground/src/graphql-yoga/resolvers.ts
+++ b/packages/playground/src/graphql-yoga/resolvers.ts
@@ -30,6 +30,24 @@ export const resolvers: Resolver = {
 
       lookahead({
         info,
+
+        until({ sourceType, field }) {
+          if (sourceType === 'Product' && field === 'color') {
+            return {
+              afterAllSelections() {
+                context.request.metaData = {
+                  ...context.request.metaData,
+                  afterAllSelections: { sourceType, field },
+                }
+              },
+            }
+          }
+          return false
+        },
+      })
+
+      lookahead({
+        info,
         state: sequelizeQueryFilters,
 
         next({ state, type }) {

--- a/packages/playground/src/graphql-yoga/resolvers.ts
+++ b/packages/playground/src/graphql-yoga/resolvers.ts
@@ -37,7 +37,10 @@ export const resolvers: Resolver = {
               afterAllSelections() {
                 context.request.metaData = {
                   ...context.request.metaData,
-                  afterAllSelections: { sourceType, field },
+                  afterAllSelections: [
+                    ...(context.request.metaData?.afterAllSelections || []),
+                    { sourceType, field },
+                  ],
                 }
               },
             }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,8 +16,8 @@ export default defineConfig({
       include: ['packages/graphql-lookahead/src/**'],
 
       thresholds: {
-        statements: 95,
-        branches: 88,
+        statements: 97,
+        branches: 90,
         functions: 100,
         lines: 100,
       },


### PR DESCRIPTION
It is now possible to run code after iterating over all selections:

```ts
lookahead({
  info,
  state: sequelizeQueryFilters,

  until({ sourceType, field }) {
    if (sourceType === 'Product' && field === 'color') {
      return {
        afterAllSelections() {
          console.log(
            'Running after iterating over all sibling fields or `color'
          )
        },
      }
    }
    return false
  },
})
```