### PR TITLE
fix: info passed to handler should be specific to current field

### DIFF
--- a/packages/playground/src/graphql-yoga/graphql-yoga.spec.ts
+++ b/packages/playground/src/graphql-yoga/graphql-yoga.spec.ts
@@ -42,6 +42,18 @@ describe('graphql-yoga', () => {
       )
     })
 
+    it('has accurate info.fieldName in meta data', () => {
+      const { fieldNames } = result.extensions?.meta?.infoSpecificToField || {}
+      const [infoField, field] = fieldNames
+      expect(infoField).toBe(field)
+    })
+
+    it('has accurate info.parentType in meta data', () => {
+      const { parentTypes } = result.extensions?.meta?.infoSpecificToField || {}
+      const [infoParentType, sourceType] = parentTypes
+      expect(infoParentType).toBe(sourceType)
+    })
+
     it('has "afterAllSelections" set to Product/color and Product/size in meta data', () => {
       expect(result.extensions?.meta?.afterAllSelections?.[0]).toEqual({
         sourceType: 'Product',


### PR DESCRIPTION
Following https://github.com/accesimpot/graphql-lookahead/pull/103

- Make the GraphQLResolveInfo specific to the current field state except for `info.path` (it will always be the initial `info.path` - to be improved)
- Cache values of `info` and `fieldDef` getters