### PR TITLE
fix: npm cli version used by OIDC in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,14 @@ jobs:
       - name: Install dependencies 👨🏻‍💻
         run: pnpm install --prod=false
 
+      # Trusted publishing: verifyConditions uses JS OIDC, but `npm publish` must use npm CLI ≥11.5.1.
+      # Node 22 still ships npm 10.x, and execa({ preferLocal: true }) does not find npm in root .bin,
+      # so the runner's old `npm` was used → ENEEDAUTH on publish.
+      - name: Use npm CLI with trusted publishing support 📌
+        run: |
+          npm install -g npm@^11.5.1
+          echo "npm $(npm --version) — OIDC publish requires 11.5.1+"
+
       - name: Any change affecting the main package❔
         id: main-package-affected
         # Make sure the job fails with exit code 1 if the nx command fails


### PR DESCRIPTION
The release workflow still failed:
https://github.com/accesimpot/graphql-lookahead/actions/runs/25052507212/job/73396008047

which is apparently due to the fact that we need to use a npm cli version >= 11.5.1