### PR TITLE
ci: fix warnings in "if" inside release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
           echo "count=${#projects_array[@]}" >> $GITHUB_OUTPUT
 
       - name: Build main package 📦
-        if: steps.main-package-affected.outputs.count > 0 || ${{ env.CI_FORCE_RELEASE_RUN }} == 'true'
+        if: ${{ steps.main-package-affected.outputs.count > 0 || env.CI_FORCE_RELEASE_RUN == 'true' }}
         run: pnpm main build
 
       # A release is made if the prefix is feat, fix, perf, chore(deps), or docs(README)
@@ -143,7 +143,7 @@ jobs:
       #   - revert: Reverts a previous commit
       #
       - name: Release
-        if: steps.main-package-affected.outputs.count > 0 || ${{ env.CI_FORCE_RELEASE_RUN }} == 'true'
+        if: ${{ steps.main-package-affected.outputs.count > 0 || env.CI_FORCE_RELEASE_RUN == 'true' }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: pnpm semantic-release


### PR DESCRIPTION
Fixing the following warnings in the release workflow:

> Conditional expression contains literal text outside replacement tokens. This will cause the expression to always evaluate to truthy. Did you mean to put the entire expression inside ${{ }}?
