### PR TITLE
feat: add nextFragment handler for union and fragment selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ type NextFragmentHandlerDetails<TState> = HandlerDetailsBase<TState> & {
 | `depth` | ❔ _Optional_ - Specify how deep it should look in the `selectionSet` (i.e. `depth: 1` is the initial `selectionSet`, `depth: null` is no limit). Default: `depth: null`. |
 | `info` | ❗️ _Required_ - GraphQLResolveInfo object which is usually the fourth argument of the resolver function. |
 | `next` | ❔ _Optional_ - Handler called for every field with subfields within the operation. It can return a state that will be passed to each `next` call of its direct child fields. See [Advanced usage](#advanced-usage). |
-Hook called for fragment selections (`next` is only called for field selections).
 | `nextFragment` | ❔ _Optional_ - Handler called for fragment selections (`next` is only called for field selections). See [Advanced usage](#fragment-selections-nextfragment). |
 | `onError` | ❔ _Optional_ - Hook called from a `try..catch` when an error is caught. Default: `(err: unknown) => { console.error(ERROR_PREFIX, err); return true }`. |
 | `state` | ❔ _Optional_ - Initial state passed to `next` and `nextFragment` (and their nested calls). See [Advanced usage](#advanced-usage). |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Use `graphql-lookahead` to check within the resolver function if particular fiel
   - [Options](#options)
 - [Advanced usage](#advanced-usage)
   - [Example: Sequelize with nested query filters](#example-sequelize-with-nested-query-filters)
-  - [Fragment selections (`onFragment`)](#fragment-selections-onfragment)
+  - [Fragment selections (`nextFragment`)](#fragment-selections-nextfragment)
   - [More examples in integration tests](#more-examples-in-integration-tests)
 - [Playground](#playground)
 - [Contribution](#contribution)
@@ -94,7 +94,7 @@ function lookahead<TState, RError extends boolean | undefined>(options: {
   depth?: number | null
   info: GraphQLResolveInfo
   next?: (details: NextHandlerDetails<TState>) => TState
-  onFragment?: (details: OnFragmentHandlerDetails<TState>) => TState
+  nextFragment?: (details: NextFragmentHandlerDetails<TState>) => TState
   onError?: (err: unknown) => RError
   state?: TState
   until?: (details: UntilHandlerDetails<TState>) => boolean
@@ -123,7 +123,7 @@ type NextHandlerDetails<TState> = HandlerDetails<TState> & {
   nextSelectionSet: SelectionSetNode
 }
 
-type OnFragmentHandlerDetails<TState> = HandlerDetailsBase<TState> & {
+type NextFragmentHandlerDetails<TState> = HandlerDetailsBase<TState> & {
   nextSelectionSet: SelectionSetNode
   selection: FragmentSpreadNode | InlineFragmentNode
 }
@@ -139,9 +139,9 @@ type OnFragmentHandlerDetails<TState> = HandlerDetailsBase<TState> & {
 | `info` | ❗️ _Required_ - GraphQLResolveInfo object which is usually the fourth argument of the resolver function. |
 | `next` | ❔ _Optional_ - Handler called for every field with subfields within the operation. It can return a state that will be passed to each `next` call of its direct child fields. See [Advanced usage](#advanced-usage). |
 Hook called for fragment selections (`next` is only called for field selections).
-| `onFragment` | ❔ _Optional_ - Hook called for fragment selections (`next` is only called for field selections). See [Advanced usage](#fragment-selections-onfragment). |
+| `nextFragment` | ❔ _Optional_ - Handler called for fragment selections (`next` is only called for field selections). See [Advanced usage](#fragment-selections-nextfragment). |
 | `onError` | ❔ _Optional_ - Hook called from a `try..catch` when an error is caught. Default: `(err: unknown) => { console.error(ERROR_PREFIX, err); return true }`. |
-| `state` | ❔ _Optional_ - Initial state passed to `next` and `onFragment` (and their nested calls). See [Advanced usage](#advanced-usage). |
+| `state` | ❔ _Optional_ - Initial state passed to `next` and `nextFragment` (and their nested calls). See [Advanced usage](#advanced-usage). |
 | `until` | ❔ _Optional_ - Handler called for every nested field within the operation. Returning true will stop the iteration and make `lookahead` return true as well. |
 
 <br>
@@ -216,9 +216,9 @@ export const resolvers: Resolver = {
 
 <br>
 
-### Fragment selections (`onFragment`)
+### Fragment selections (`nextFragment`)
 
-For each **fragment** step in the operation (`... on Type { }` or `...FragmentName`), `lookahead` calls `onFragment` instead of `next`. It has the same `state` and return contract as `next` for nested handlers.
+For each fragment step in the operation (`... on Type { }` or `...FragmentName`), `lookahead` calls `nextFragment` instead of `next`. It has the same `state` and return contract as `next` for nested handlers.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ export const resolvers: Resolver = {
 
 For each fragment step in the operation (`... on Type { }` or `...FragmentName`), `lookahead` calls `nextFragment` instead of `next`. It has the same `state` and return contract as `next` for nested handlers.
 
+Inline fragments without a type condition (e.g. `... @include(if: true) { }`) do _not_ invoke `nextFragment` (or `next` / `until` for that node). The walker still descends into their selection set using the parent GraphQL type and the current `state`.
+
 <br>
 
 ### More examples in integration tests

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Use `graphql-lookahead` to check within the resolver function if particular fiel
   - [Options](#options)
 - [Advanced usage](#advanced-usage)
   - [Example: Sequelize with nested query filters](#example-sequelize-with-nested-query-filters)
+  - [Fragment selections (`onFragment`)](#fragment-selections-onfragment)
   - [More examples in integration tests](#more-examples-in-integration-tests)
 - [Playground](#playground)
 - [Contribution](#contribution)
@@ -93,19 +94,25 @@ function lookahead<TState, RError extends boolean | undefined>(options: {
   depth?: number | null
   info: GraphQLResolveInfo
   next?: (details: NextHandlerDetails<TState>) => TState
+  onFragment?: (details: OnFragmentHandlerDetails<TState>) => TState
   onError?: (err: unknown) => RError
   state?: TState
   until?: (details: UntilHandlerDetails<TState>) => boolean
 }): boolean
 
-type HandlerDetails<TState> = {
+type HandlerDetailsBase<TState> = {
+  info: GraphQLResolveInfo
+  sourceType: string
+  state: TState
+  type: string
+}
+
+type HandlerDetails<TState> = HandlerDetailsBase<TState> & {
   args: { [arg: string]: unknown }
   field: string
   fieldDef: GraphQLField
   isList: boolean
   selection: FieldNode
-  state: TState
-  type: string
 }
 
 type UntilHandlerDetails<TState> = HandlerDetails<TState> & {
@@ -114,6 +121,11 @@ type UntilHandlerDetails<TState> = HandlerDetails<TState> & {
 
 type NextHandlerDetails<TState> = HandlerDetails<TState> & {
   nextSelectionSet: SelectionSetNode
+}
+
+type OnFragmentHandlerDetails<TState> = HandlerDetailsBase<TState> & {
+  nextSelectionSet: SelectionSetNode
+  selection: FragmentSpreadNode | InlineFragmentNode
 }
 ```
 
@@ -126,8 +138,10 @@ type NextHandlerDetails<TState> = HandlerDetails<TState> & {
 | `depth` | ❔ _Optional_ - Specify how deep it should look in the `selectionSet` (i.e. `depth: 1` is the initial `selectionSet`, `depth: null` is no limit). Default: `depth: null`. |
 | `info` | ❗️ _Required_ - GraphQLResolveInfo object which is usually the fourth argument of the resolver function. |
 | `next` | ❔ _Optional_ - Handler called for every field with subfields within the operation. It can return a state that will be passed to each `next` call of its direct child fields. See [Advanced usage](#advanced-usage). |
+Hook called for fragment selections (`next` is only called for field selections).
+| `onFragment` | ❔ _Optional_ - Hook called for fragment selections (`next` is only called for field selections). See [Advanced usage](#fragment-selections-onfragment). |
 | `onError` | ❔ _Optional_ - Hook called from a `try..catch` when an error is caught. Default: `(err: unknown) => { console.error(ERROR_PREFIX, err); return true }`. |
-| `state` | ❔ _Optional_ - Initial state used in `next` handler. See [Advanced usage](#advanced-usage).|
+| `state` | ❔ _Optional_ - Initial state passed to `next` and `onFragment` (and their nested calls). See [Advanced usage](#advanced-usage). |
 | `until` | ❔ _Optional_ - Handler called for every nested field within the operation. Returning true will stop the iteration and make `lookahead` return true as well. |
 
 <br>
@@ -199,6 +213,12 @@ export const resolvers: Resolver = {
   },
 }
 ```
+
+<br>
+
+### Fragment selections (`onFragment`)
+
+For each **fragment** step in the operation (`... on Type { }` or `...FragmentName`), `lookahead` calls `onFragment` instead of `next`. It has the same `state` and return contract as `next` for nested handlers.
 
 <br>
 

--- a/packages/graphql-lookahead/src/utils/main.ts
+++ b/packages/graphql-lookahead/src/utils/main.ts
@@ -220,6 +220,31 @@ function lookDeeperWithDefaults<TState>(options: {
 
   // Each selection represents a field or a fragment you're requesting inside the operation
   for (const selection of options.selectionSet.selections) {
+    // Inline fragment without `on Type` (e.g. `... { f }` or `... @include(if: true) { f }`): no
+    // handlers, but keep traversing with the parent type and current state.
+    if (
+      selection.kind === 'InlineFragment' &&
+      !selection.typeCondition &&
+      selection.selectionSet &&
+      options.type
+    ) {
+      if (options.depth !== null && options.depthIndex >= options.depth - 1) continue
+
+      const returnValue = lookDeeperWithDefaults({
+        depth: options.depth,
+        depthIndex: options.depthIndex + 1,
+        info: options.info,
+        next: options.next,
+        nextFragment: options.nextFragment,
+        selectionSet: selection.selectionSet,
+        state: options.state,
+        type: options.type,
+        until: options.until,
+      })
+      if (returnValue) return returnValue
+      continue
+    }
+
     const selectionName = findSelectionName(selection)
 
     // This should only happen if the selection is invalid

--- a/packages/graphql-lookahead/src/utils/main.ts
+++ b/packages/graphql-lookahead/src/utils/main.ts
@@ -66,9 +66,9 @@ export type OnFragmentHandlerDetails<TState> = HandlerDetailsBase<TState> & {
  * @param options.depth - Specify how deep it should look in the `selectionSet` (i.e. `depth: 1` is the initial `selectionSet`, `depth: null` is no limit). Default: `depth: null`.
  * @param options.info - GraphQLResolveInfo object which is usually the fourth argument of the resolver function.
  * @param options.next - Handler called for every field with subfields within the operation. It can return a state that will be passed to each `next` call of its direct child fields. See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
- * @param options.onFragment - Handler called for inline fragments and fragment spreads (not used together with `next` on the same selection). Receives the same `state` as `next` for that depth and may return the state passed to nested walks.
+ * @param options.onFragment - Hook called for fragment selections (`next` is only called for field selections). See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
  * @param options.onError - Hook called from a `try..catch` when an error is caught. Default: `(err: unknown) => { console.error(ERROR_PREFIX, err); return true }`.
- * @param options.state - Initial state threaded through `next` and `onFragment` (and their nested calls).
+ * @param options.state - Initial state passed to `next` and `onFragment` (and their nested calls). See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
  * @param options.until - Handler called for every nested field within the operation. Returning true will stop the iteration and make `lookahead` return true as well.
  */
 export function lookahead<TState, RError extends boolean | undefined>(options: {
@@ -146,7 +146,7 @@ export function lookaheadAndThrow<TState, RError extends boolean | undefined>(op
  *
  * @param options.depth - Specify how deep it should look in the `selectionSet` (i.e. `depth: 1` is the initial `selectionSet`, `depth: null` is no limit). Default: `depth: null`.
  * @param options.next - Handler called for every field with subfields within the operation. It can return a state that will be passed to each `next` call of its direct child fields. See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
- * @param options.onFragment - Hook called for fragment selections (`next` is only called for field selections); see `lookahead`.
+ * @param options.onFragment - Hook called for fragment selections (`next` is only called for field selections). See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
  * @param options.onError - Hook called from a `try..catch` when an error is caught. Default: `(err: unknown) => { console.error(ERROR_PREFIX, err); return true }`.
  * @param options.schema - GraphQLResolveInfo['schema'] object
  * @param options.selectionSet - SelectionSetNode picked from GraphQLResolveInfo['operation']

--- a/packages/graphql-lookahead/src/utils/main.ts
+++ b/packages/graphql-lookahead/src/utils/main.ts
@@ -14,7 +14,19 @@ import { getSelectionDetails, findTypeName, findSelectionName, getChildFields } 
 
 const ERROR_PREFIX = '[graphql-lookahead]'
 
-export type HandlerDetails<TState> = {
+/**
+ * Fields shared by {@link HandlerDetails} and {@link OnFragmentHandlerDetails}.
+ * For field handlers, `type` is the selected field’s output type.
+ * For fragment handlers, `type` is the fragment condition type (`on` / `fragment ... on`).
+ */
+export type HandlerDetailsBase<TState> = {
+  info: GraphQLResolveInfo
+  sourceType: string
+  state: TState
+  type: string
+}
+
+export type HandlerDetails<TState> = HandlerDetailsBase<TState> & {
   args: { [arg: string]: unknown }
   field: string
   /** @private */
@@ -22,15 +34,11 @@ export type HandlerDetails<TState> = {
   fieldDef: GraphQLField<any, any> // eslint-disable-line @typescript-eslint/no-explicit-any
   /** @private */
   _info?: GraphQLResolveInfo
-  info: GraphQLResolveInfo
   /**
    * Whether or not the current field type is a GraphQL List (`[Foo!]` is a list, `Foo!` is not).
    */
   isList: boolean
   selection: FieldNode
-  sourceType: string
-  state: TState
-  type: string
 }
 
 export type UntilHandlerDetails<TState> = HandlerDetails<TState> & {
@@ -45,6 +53,11 @@ export type NextHandlerDetails<TState> = HandlerDetails<TState> & {
   nextSelectionSet: SelectionSetNode
 }
 
+export type OnFragmentHandlerDetails<TState> = HandlerDetailsBase<TState> & {
+  nextSelectionSet: SelectionSetNode
+  selection: FragmentSpreadNode | InlineFragmentNode
+}
+
 /**
  * Use `lookahead` to check within the resolver function if particular fields are part of the
  * operation (`info.operation`). This allows you to avoid querying nested database relationships
@@ -53,14 +66,16 @@ export type NextHandlerDetails<TState> = HandlerDetails<TState> & {
  * @param options.depth - Specify how deep it should look in the `selectionSet` (i.e. `depth: 1` is the initial `selectionSet`, `depth: null` is no limit). Default: `depth: null`.
  * @param options.info - GraphQLResolveInfo object which is usually the fourth argument of the resolver function.
  * @param options.next - Handler called for every field with subfields within the operation. It can return a state that will be passed to each `next` call of its direct child fields. See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
+ * @param options.onFragment - Handler called for inline fragments and fragment spreads (not used together with `next` on the same selection). Receives the same `state` as `next` for that depth and may return the state passed to nested walks.
  * @param options.onError - Hook called from a `try..catch` when an error is caught. Default: `(err: unknown) => { console.error(ERROR_PREFIX, err); return true }`.
- * @param options.state - Initial state used in `next` handler. See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
+ * @param options.state - Initial state threaded through `next` and `onFragment` (and their nested calls).
  * @param options.until - Handler called for every nested field within the operation. Returning true will stop the iteration and make `lookahead` return true as well.
  */
 export function lookahead<TState, RError extends boolean | undefined>(options: {
   depth?: number | null
   info: GraphQLResolveInfo
   next?: (details: NextHandlerDetails<TState>) => TState
+  onFragment?: (details: OnFragmentHandlerDetails<TState>) => TState
   onError?: (err: unknown) => RError
   state?: TState
   until?: (details: UntilHandlerDetails<TState>) => UntilHandlerDetailsReturn<TState>
@@ -91,6 +106,7 @@ export function lookaheadAndThrow<TState, RError extends boolean | undefined>(op
   depth?: number | null
   info: GraphQLResolveInfo
   next?: (details: NextHandlerDetails<TState>) => TState
+  onFragment?: (details: OnFragmentHandlerDetails<TState>) => TState
   onError?: (err: unknown) => RError
   state?: TState
   until?: (details: UntilHandlerDetails<TState>) => UntilHandlerDetailsReturn<TState>
@@ -110,6 +126,7 @@ export function lookaheadAndThrow<TState, RError extends boolean | undefined>(op
       depth: options.depth,
       info,
       next: options.next,
+      onFragment: options.onFragment,
       onError: options.onError,
       selectionSet,
       state,
@@ -129,16 +146,18 @@ export function lookaheadAndThrow<TState, RError extends boolean | undefined>(op
  *
  * @param options.depth - Specify how deep it should look in the `selectionSet` (i.e. `depth: 1` is the initial `selectionSet`, `depth: null` is no limit). Default: `depth: null`.
  * @param options.next - Handler called for every field with subfields within the operation. It can return a state that will be passed to each `next` call of its direct child fields. See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
+ * @param options.onFragment - Hook called for fragment selections (`next` is only called for field selections); see `lookahead`.
  * @param options.onError - Hook called from a `try..catch` when an error is caught. Default: `(err: unknown) => { console.error(ERROR_PREFIX, err); return true }`.
  * @param options.schema - GraphQLResolveInfo['schema'] object
  * @param options.selectionSet - SelectionSetNode picked from GraphQLResolveInfo['operation']
- * @param options.state - Initial state used in `next` handler. See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
+ * @param options.state - Initial state passed to `next` and `onFragment` (and their nested calls). See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
  * @param options.until - Handler called for every nested field within the operation. Returning true will stop the iteration and make `lookahead` return true as well.
  */
 export function lookDeeper<TState, RError extends boolean | undefined>(options: {
   depth?: number | null
   info: GraphQLResolveInfo
   next?: (details: NextHandlerDetails<TState>) => TState
+  onFragment?: (details: OnFragmentHandlerDetails<TState>) => TState
   onError?: (err: unknown) => RError
   selectionSet: SelectionSetNode
   state: TState
@@ -171,6 +190,7 @@ export function lookDeeperAndThrow<TState>(options: {
   depth?: number | null
   info: GraphQLResolveInfo
   next?: (details: NextHandlerDetails<TState>) => TState
+  onFragment?: (details: OnFragmentHandlerDetails<TState>) => TState
   selectionSet: SelectionSetNode
   state: TState
   type: string
@@ -178,9 +198,11 @@ export function lookDeeperAndThrow<TState>(options: {
 }): boolean {
   const depth: number | null = typeof options.depth === 'number' ? options.depth : null
   const next: NonNullable<typeof options.next> = options.next || (() => options.state)
+  const onFragment: NonNullable<typeof options.onFragment> =
+    options.onFragment || (() => options.state)
   const until: NonNullable<typeof options.until> = options.until || (() => false)
 
-  return !!lookDeeperWithDefaults({ ...options, depth, depthIndex: 0, next, until })
+  return !!lookDeeperWithDefaults({ ...options, depth, depthIndex: 0, next, onFragment, until })
 }
 
 function lookDeeperWithDefaults<TState>(options: {
@@ -188,6 +210,7 @@ function lookDeeperWithDefaults<TState>(options: {
   depthIndex: number
   info: GraphQLResolveInfo
   next: (details: NextHandlerDetails<TState>) => TState
+  onFragment: (details: OnFragmentHandlerDetails<TState>) => TState
   selectionSet: SelectionSetNode
   state: TState
   type: string
@@ -212,8 +235,19 @@ function lookDeeperWithDefaults<TState>(options: {
     if (selectionTypeName) {
       let lookDeeperState = options.state
 
-      if (!isFragmentSelection) {
-        // We execute the handlers only if it is not a fragment selection
+      if (isFragmentSelection) {
+        if (nextSelectionSet)
+          lookDeeperState = options.onFragment({
+            info: options.info,
+            nextSelectionSet,
+            selection: selection as FragmentSpreadNode | InlineFragmentNode,
+            sourceType: options.type,
+            state: options.state,
+            type: selectionTypeName,
+          })
+      }
+      // Execute `until` and `next` handlers only for field selections (fragments use `onFragment`).
+      else {
         const accurateSelection = selection as Exclude<
           typeof selection,
           FragmentSpreadNode | InlineFragmentNode
@@ -300,6 +334,7 @@ function lookDeeperWithDefaults<TState>(options: {
           depthIndex: options.depthIndex + 1,
           info: options.info,
           next: options.next,
+          onFragment: options.onFragment,
           selectionSet: nextSelectionSet,
           state: lookDeeperState,
           type: selectionTypeName,

--- a/packages/graphql-lookahead/src/utils/main.ts
+++ b/packages/graphql-lookahead/src/utils/main.ts
@@ -197,9 +197,9 @@ export function lookDeeperAndThrow<TState>(options: {
   until?: (details: UntilHandlerDetails<TState>) => UntilHandlerDetailsReturn<TState>
 }): boolean {
   const depth: number | null = typeof options.depth === 'number' ? options.depth : null
-  const next: NonNullable<typeof options.next> = options.next || (() => options.state)
+  const next: NonNullable<typeof options.next> = options.next || (({ state }) => state)
   const nextFragment: NonNullable<typeof options.nextFragment> =
-    options.nextFragment || (() => options.state)
+    options.nextFragment || (({ state }) => state)
   const until: NonNullable<typeof options.until> = options.until || (() => false)
 
   return !!lookDeeperWithDefaults({ ...options, depth, depthIndex: 0, next, nextFragment, until })

--- a/packages/graphql-lookahead/src/utils/main.ts
+++ b/packages/graphql-lookahead/src/utils/main.ts
@@ -15,7 +15,7 @@ import { getSelectionDetails, findTypeName, findSelectionName, getChildFields } 
 const ERROR_PREFIX = '[graphql-lookahead]'
 
 /**
- * Fields shared by {@link HandlerDetails} and {@link OnFragmentHandlerDetails}.
+ * Fields shared by {@link HandlerDetails} and {@link NextFragmentHandlerDetails}.
  * For field handlers, `type` is the selected field’s output type.
  * For fragment handlers, `type` is the fragment condition type (`on` / `fragment ... on`).
  */
@@ -53,7 +53,7 @@ export type NextHandlerDetails<TState> = HandlerDetails<TState> & {
   nextSelectionSet: SelectionSetNode
 }
 
-export type OnFragmentHandlerDetails<TState> = HandlerDetailsBase<TState> & {
+export type NextFragmentHandlerDetails<TState> = HandlerDetailsBase<TState> & {
   nextSelectionSet: SelectionSetNode
   selection: FragmentSpreadNode | InlineFragmentNode
 }
@@ -66,16 +66,16 @@ export type OnFragmentHandlerDetails<TState> = HandlerDetailsBase<TState> & {
  * @param options.depth - Specify how deep it should look in the `selectionSet` (i.e. `depth: 1` is the initial `selectionSet`, `depth: null` is no limit). Default: `depth: null`.
  * @param options.info - GraphQLResolveInfo object which is usually the fourth argument of the resolver function.
  * @param options.next - Handler called for every field with subfields within the operation. It can return a state that will be passed to each `next` call of its direct child fields. See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
- * @param options.onFragment - Hook called for fragment selections (`next` is only called for field selections). See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
+ * @param options.nextFragment - Handler called for fragment selections (`next` is only called for field selections). See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
  * @param options.onError - Hook called from a `try..catch` when an error is caught. Default: `(err: unknown) => { console.error(ERROR_PREFIX, err); return true }`.
- * @param options.state - Initial state passed to `next` and `onFragment` (and their nested calls). See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
+ * @param options.state - Initial state passed to `next` and `nextFragment` (and their nested calls). See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
  * @param options.until - Handler called for every nested field within the operation. Returning true will stop the iteration and make `lookahead` return true as well.
  */
 export function lookahead<TState, RError extends boolean | undefined>(options: {
   depth?: number | null
   info: GraphQLResolveInfo
   next?: (details: NextHandlerDetails<TState>) => TState
-  onFragment?: (details: OnFragmentHandlerDetails<TState>) => TState
+  nextFragment?: (details: NextFragmentHandlerDetails<TState>) => TState
   onError?: (err: unknown) => RError
   state?: TState
   until?: (details: UntilHandlerDetails<TState>) => UntilHandlerDetailsReturn<TState>
@@ -106,7 +106,7 @@ export function lookaheadAndThrow<TState, RError extends boolean | undefined>(op
   depth?: number | null
   info: GraphQLResolveInfo
   next?: (details: NextHandlerDetails<TState>) => TState
-  onFragment?: (details: OnFragmentHandlerDetails<TState>) => TState
+  nextFragment?: (details: NextFragmentHandlerDetails<TState>) => TState
   onError?: (err: unknown) => RError
   state?: TState
   until?: (details: UntilHandlerDetails<TState>) => UntilHandlerDetailsReturn<TState>
@@ -126,7 +126,7 @@ export function lookaheadAndThrow<TState, RError extends boolean | undefined>(op
       depth: options.depth,
       info,
       next: options.next,
-      onFragment: options.onFragment,
+      nextFragment: options.nextFragment,
       onError: options.onError,
       selectionSet,
       state,
@@ -146,18 +146,18 @@ export function lookaheadAndThrow<TState, RError extends boolean | undefined>(op
  *
  * @param options.depth - Specify how deep it should look in the `selectionSet` (i.e. `depth: 1` is the initial `selectionSet`, `depth: null` is no limit). Default: `depth: null`.
  * @param options.next - Handler called for every field with subfields within the operation. It can return a state that will be passed to each `next` call of its direct child fields. See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
- * @param options.onFragment - Hook called for fragment selections (`next` is only called for field selections). See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
+ * @param options.nextFragment - Handler called for fragment selections (`next` is only called for field selections). See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
  * @param options.onError - Hook called from a `try..catch` when an error is caught. Default: `(err: unknown) => { console.error(ERROR_PREFIX, err); return true }`.
  * @param options.schema - GraphQLResolveInfo['schema'] object
  * @param options.selectionSet - SelectionSetNode picked from GraphQLResolveInfo['operation']
- * @param options.state - Initial state passed to `next` and `onFragment` (and their nested calls). See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
+ * @param options.state - Initial state passed to `next` and `nextFragment` (and their nested calls). See [Advanced usage](https://github.com/accesimpot/graphql-lookahead#advanced-usage).
  * @param options.until - Handler called for every nested field within the operation. Returning true will stop the iteration and make `lookahead` return true as well.
  */
 export function lookDeeper<TState, RError extends boolean | undefined>(options: {
   depth?: number | null
   info: GraphQLResolveInfo
   next?: (details: NextHandlerDetails<TState>) => TState
-  onFragment?: (details: OnFragmentHandlerDetails<TState>) => TState
+  nextFragment?: (details: NextFragmentHandlerDetails<TState>) => TState
   onError?: (err: unknown) => RError
   selectionSet: SelectionSetNode
   state: TState
@@ -190,7 +190,7 @@ export function lookDeeperAndThrow<TState>(options: {
   depth?: number | null
   info: GraphQLResolveInfo
   next?: (details: NextHandlerDetails<TState>) => TState
-  onFragment?: (details: OnFragmentHandlerDetails<TState>) => TState
+  nextFragment?: (details: NextFragmentHandlerDetails<TState>) => TState
   selectionSet: SelectionSetNode
   state: TState
   type: string
@@ -198,11 +198,11 @@ export function lookDeeperAndThrow<TState>(options: {
 }): boolean {
   const depth: number | null = typeof options.depth === 'number' ? options.depth : null
   const next: NonNullable<typeof options.next> = options.next || (() => options.state)
-  const onFragment: NonNullable<typeof options.onFragment> =
-    options.onFragment || (() => options.state)
+  const nextFragment: NonNullable<typeof options.nextFragment> =
+    options.nextFragment || (() => options.state)
   const until: NonNullable<typeof options.until> = options.until || (() => false)
 
-  return !!lookDeeperWithDefaults({ ...options, depth, depthIndex: 0, next, onFragment, until })
+  return !!lookDeeperWithDefaults({ ...options, depth, depthIndex: 0, next, nextFragment, until })
 }
 
 function lookDeeperWithDefaults<TState>(options: {
@@ -210,7 +210,7 @@ function lookDeeperWithDefaults<TState>(options: {
   depthIndex: number
   info: GraphQLResolveInfo
   next: (details: NextHandlerDetails<TState>) => TState
-  onFragment: (details: OnFragmentHandlerDetails<TState>) => TState
+  nextFragment: (details: NextFragmentHandlerDetails<TState>) => TState
   selectionSet: SelectionSetNode
   state: TState
   type: string
@@ -237,7 +237,7 @@ function lookDeeperWithDefaults<TState>(options: {
 
       if (isFragmentSelection) {
         if (nextSelectionSet)
-          lookDeeperState = options.onFragment({
+          lookDeeperState = options.nextFragment({
             info: options.info,
             nextSelectionSet,
             selection: selection as FragmentSpreadNode | InlineFragmentNode,
@@ -246,7 +246,7 @@ function lookDeeperWithDefaults<TState>(options: {
             type: selectionTypeName,
           })
       }
-      // Execute `until` and `next` handlers only for field selections (fragments use `onFragment`).
+      // Execute `until` and `next` handlers only for field selections (fragments use `nextFragment`).
       else {
         const accurateSelection = selection as Exclude<
           typeof selection,
@@ -334,7 +334,7 @@ function lookDeeperWithDefaults<TState>(options: {
           depthIndex: options.depthIndex + 1,
           info: options.info,
           next: options.next,
-          onFragment: options.onFragment,
+          nextFragment: options.nextFragment,
           selectionSet: nextSelectionSet,
           state: lookDeeperState,
           type: selectionTypeName,

--- a/packages/graphql-lookahead/src/utils/nextFragment.spec.ts
+++ b/packages/graphql-lookahead/src/utils/nextFragment.spec.ts
@@ -5,10 +5,11 @@ import {
   GraphQLSchema,
   GraphQLString,
   GraphQLUnionType,
+  GraphQLInt,
   graphql,
   type GraphQLResolveInfo,
 } from 'graphql'
-import { lookaheadAndThrow } from './main'
+import { lookaheadAndThrow, lookahead } from './main'
 
 type PathState = { path: string[] }
 
@@ -112,6 +113,151 @@ describe('default next', () => {
     expect(result.errors).toBeUndefined()
     expect(childFieldState?.path).toEqual(['frag'])
     expect(childFieldState).not.toHaveProperty('isInitialState')
+  })
+})
+
+describe('untyped inline fragments', () => {
+  it('walks nested selections without calling nextFragment', async () => {
+    let nextFragmentCalls = 0
+    const untilFields: string[] = []
+
+    const orderType = new GraphQLObjectType({
+      name: 'Order',
+      fields: {
+        status: { type: new GraphQLNonNull(GraphQLString) },
+        total: { type: new GraphQLNonNull(GraphQLInt) },
+      },
+    })
+    const queryType = new GraphQLObjectType({
+      name: 'Query',
+      fields: {
+        order: {
+          type: orderType,
+          resolve(_root, _args, _ctx, info) {
+            lookaheadAndThrow({
+              info,
+              state: { path: [] } as PathState,
+              nextFragment() {
+                nextFragmentCalls++
+                return { path: [] }
+              },
+              until({ field }) {
+                untilFields.push(field)
+                return false
+              },
+            })
+            return { status: 'ok', total: 1 }
+          },
+        },
+      },
+    })
+    const schema = new GraphQLSchema({ query: queryType })
+
+    const result = await graphql({
+      schema,
+      source: `
+        query {
+          order {
+            ... {
+              total
+            }
+          }
+        }
+      `,
+    })
+
+    expect(result.errors).toBeUndefined()
+    expect(nextFragmentCalls).toBe(0)
+    expect(untilFields).toContain('total')
+  })
+
+  it('does not descend into untyped fragment when depth stops at parent', async () => {
+    const untilFields: string[] = []
+
+    const orderType = new GraphQLObjectType({
+      name: 'Order',
+      fields: {
+        total: { type: new GraphQLNonNull(GraphQLInt) },
+      },
+    })
+    const queryType = new GraphQLObjectType({
+      name: 'Query',
+      fields: {
+        order: {
+          type: orderType,
+          resolve(_root, _args, _ctx, info) {
+            lookaheadAndThrow({
+              info,
+              depth: 1,
+              state: { path: [] } as PathState,
+              until({ field }) {
+                untilFields.push(field)
+                return false
+              },
+            })
+            return { total: 1 }
+          },
+        },
+      },
+    })
+    const schema = new GraphQLSchema({ query: queryType })
+
+    const result = await graphql({
+      schema,
+      source: `
+        query {
+          order {
+            ... {
+              total
+            }
+          }
+        }
+      `,
+    })
+
+    expect(result.errors).toBeUndefined()
+    expect(untilFields).toHaveLength(0)
+  })
+
+  it('returns true when until matches inside untyped inline fragment', async () => {
+    const orderType = new GraphQLObjectType({
+      name: 'Order',
+      fields: {
+        total: { type: new GraphQLNonNull(GraphQLInt) },
+      },
+    })
+    const queryType = new GraphQLObjectType({
+      name: 'Query',
+      fields: {
+        order: {
+          type: orderType,
+          resolve(_root, _args, _ctx, info) {
+            const hit = lookahead({
+              info,
+              until: ({ field }) => field === 'total',
+            })
+            expect(hit).toBe(true)
+            return { total: 1 }
+          },
+        },
+      },
+    })
+    const schema = new GraphQLSchema({ query: queryType })
+
+    const result = await graphql({
+      schema,
+      source: `
+        query {
+          order {
+            ... {
+              total
+            }
+          }
+        }
+      `,
+    })
+
+    expect(result.errors).toBeUndefined()
   })
 })
 

--- a/packages/graphql-lookahead/src/utils/nextFragment.spec.ts
+++ b/packages/graphql-lookahead/src/utils/nextFragment.spec.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from 'vitest'
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+  GraphQLUnionType,
+  graphql,
+  type GraphQLResolveInfo,
+} from 'graphql'
+import { lookaheadAndThrow } from './main'
+
+type PathState = { path: string[] }
+
+function schemaWithPageAndBoxUnion(onPage: (info: GraphQLResolveInfo) => void) {
+  const innerType = new GraphQLObjectType({
+    name: 'Inner',
+    fields: {
+      child: {
+        type: new GraphQLObjectType({
+          name: 'InnerChild',
+          fields: {
+            leaf: { type: new GraphQLNonNull(GraphQLString) },
+          },
+        }),
+      },
+    },
+  })
+  const bigBox = new GraphQLObjectType({
+    name: 'BigBox',
+    fields: {
+      inner: { type: new GraphQLNonNull(innerType) },
+    },
+  })
+  const smallBox = new GraphQLObjectType({
+    name: 'SmallBox',
+    fields: {
+      label: { type: new GraphQLNonNull(GraphQLString) },
+    },
+  })
+  const boxUnion = new GraphQLUnionType({
+    name: 'Box',
+    types: [bigBox, smallBox],
+    resolveType(value: { __typename: string }) {
+      return value.__typename
+    },
+  })
+  const pageType = new GraphQLObjectType({
+    name: 'Page',
+    fields: {
+      content: {
+        type: boxUnion,
+        resolve: () => ({
+          __typename: 'BigBox',
+          inner: { child: { leaf: 'x' } },
+        }),
+      },
+    },
+  })
+  const queryType = new GraphQLObjectType({
+    name: 'Query',
+    fields: {
+      page: {
+        type: pageType,
+        resolve(_root, _args, _ctx, info) {
+          onPage(info)
+          return {}
+        },
+      },
+    },
+  })
+  return new GraphQLSchema({ query: queryType })
+}
+
+describe('default next', () => {
+  it('passes through branch state from nextFragment when next is omitted', async () => {
+    let childFieldState: PathState | undefined
+    const schema = schemaWithPageAndBoxUnion(info => {
+      lookaheadAndThrow({
+        info,
+        state: { path: [], isInitialState: true } as PathState & { isInitialState?: true },
+        nextFragment({ state, type }) {
+          if (type === 'BigBox') return { path: [...state.path, 'frag'] }
+          return state
+        },
+        until({ field, state }) {
+          if (field === 'child') childFieldState = state
+          return false
+        },
+      })
+    })
+
+    const result = await graphql({
+      schema,
+      source: `
+        query {
+          page {
+            content {
+              ... on BigBox {
+                inner {
+                  child {
+                    leaf
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+    })
+
+    expect(result.errors).toBeUndefined()
+    expect(childFieldState?.path).toEqual(['frag'])
+    expect(childFieldState).not.toHaveProperty('isInitialState')
+  })
+})
+
+describe('default nextFragment', () => {
+  it('passes through current branch state when nextFragment is omitted', async () => {
+    const nextPaths: string[][] = []
+    const schema = schemaWithPageAndBoxUnion(info => {
+      lookaheadAndThrow({
+        info,
+        state: { path: [] } as PathState,
+        next({ state, field }) {
+          const nextState: PathState = { path: [...state.path, field] }
+          nextPaths.push([...nextState.path])
+          return nextState
+        },
+        // no nextFragment: must not reset to the root state inside the fragment
+      })
+    })
+
+    const result = await graphql({
+      schema,
+      source: `
+        query {
+          page {
+            content {
+              ... on BigBox {
+                inner {
+                  child {
+                    leaf
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+    })
+
+    expect(result.errors).toBeUndefined()
+    expect(nextPaths).toEqual([['content'], ['content', 'inner'], ['content', 'inner', 'child']])
+  })
+
+  it('still allows custom nextFragment to override branch state', async () => {
+    const nextPaths: string[][] = []
+    const schema = schemaWithPageAndBoxUnion(info => {
+      lookaheadAndThrow({
+        info,
+        state: { path: [], isInitialState: true } as PathState & { isInitialState?: true },
+        next({ state, field }) {
+          if (field === 'content') {
+            expect(state.isInitialState).toBe(true)
+          } else {
+            expect(state.isInitialState).toBeUndefined()
+          }
+          const nextState: PathState = { path: [...state.path, field] }
+          nextPaths.push([...nextState.path])
+          return nextState
+        },
+        nextFragment({ state, type }) {
+          expect(state.isInitialState).toBeUndefined()
+
+          if (type === 'BigBox') return { path: [...state.path, '__frag__'] }
+          return state
+        },
+      })
+    })
+
+    const result = await graphql({
+      schema,
+      source: `
+        query {
+          page {
+            content {
+              ... on BigBox {
+                inner {
+                  child {
+                    leaf
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+    })
+
+    expect(result.errors).toBeUndefined()
+    expect(nextPaths).toEqual([
+      ['content'],
+      ['content', '__frag__', 'inner'],
+      ['content', '__frag__', 'inner', 'child'],
+    ])
+  })
+})

--- a/packages/playground/src/graphql-yoga/graphql-yoga.spec.ts
+++ b/packages/playground/src/graphql-yoga/graphql-yoga.spec.ts
@@ -145,6 +145,10 @@ describe('graphql-yoga', () => {
         ],
       })
     })
+
+    it('has empty order onFragmentTrace (no fragments in query)', () => {
+      expect(result.extensions?.meta?.['Query.order'].onFragmentTrace).toEqual([])
+    })
   })
 
   describe('when it sends partial cart query', async () => {
@@ -199,6 +203,17 @@ describe('graphql-yoga', () => {
       it('finds "products" as the first list field', () => {
         expect(result.extensions?.meta?.['Query.page'].firstListFound).toEqual('products')
       })
+
+      it('invokes onFragment with union and concrete types for inline fragments', () => {
+        expect(result.extensions?.meta?.['Query.page'].onFragmentTrace).toEqual([
+          { fragmentType: 'ProductPageContent', sourceType: 'PageContent' },
+          { fragmentType: 'Product', sourceType: 'Product' },
+        ])
+      })
+
+      it('passes onFragment return state to nested next (e.g. products field)', () => {
+        expect(result.extensions?.meta?.productPageProductsNextStateTag).toBe('fromOnFragment')
+      })
     })
 
     describe('when lookahead is called within non-Query field resolver', async () => {
@@ -213,6 +228,18 @@ describe('graphql-yoga', () => {
         expect(
           result.extensions?.meta?.['ProductPageContent.products'].sequelizeQueryFilters
         ).toEqual({ include: [{ model: 'Inventory' }] })
+      })
+
+      it('invokes onFragment for the inline spread on Product', () => {
+        expect(result.extensions?.meta?.['ProductPageContent.products'].onFragmentTrace).toEqual([
+          { fragmentType: 'Product', sourceType: 'Product' },
+        ])
+      })
+
+      it('invokes onFragment for the named fragment on Product in the order selection', () => {
+        expect(result.extensions?.meta?.['Query.order'].onFragmentTrace).toEqual([
+          { fragmentType: 'Product', sourceType: 'Product' },
+        ])
       })
 
       describe('when looking at first call of `Product.inventory` in meta data', () => {

--- a/packages/playground/src/graphql-yoga/graphql-yoga.spec.ts
+++ b/packages/playground/src/graphql-yoga/graphql-yoga.spec.ts
@@ -146,8 +146,8 @@ describe('graphql-yoga', () => {
       })
     })
 
-    it('has empty order onFragmentTrace (no fragments in query)', () => {
-      expect(result.extensions?.meta?.['Query.order'].onFragmentTrace).toEqual([])
+    it('has empty order nextFragmentTrace (no fragments in query)', () => {
+      expect(result.extensions?.meta?.['Query.order'].nextFragmentTrace).toEqual([])
     })
   })
 
@@ -204,15 +204,15 @@ describe('graphql-yoga', () => {
         expect(result.extensions?.meta?.['Query.page'].firstListFound).toEqual('products')
       })
 
-      it('invokes onFragment with union and concrete types for inline fragments', () => {
-        expect(result.extensions?.meta?.['Query.page'].onFragmentTrace).toEqual([
+      it('invokes nextFragment with union and concrete types for inline fragments', () => {
+        expect(result.extensions?.meta?.['Query.page'].nextFragmentTrace).toEqual([
           { fragmentType: 'ProductPageContent', sourceType: 'PageContent' },
           { fragmentType: 'Product', sourceType: 'Product' },
         ])
       })
 
-      it('passes onFragment return state to nested next (e.g. products field)', () => {
-        expect(result.extensions?.meta?.productPageProductsNextStateTag).toBe('fromOnFragment')
+      it('passes nextFragment return state to nested next (e.g. products field)', () => {
+        expect(result.extensions?.meta?.productPageProductsNextStateTag).toBe('fromNextFragment')
       })
     })
 
@@ -230,14 +230,14 @@ describe('graphql-yoga', () => {
         ).toEqual({ include: [{ model: 'Inventory' }] })
       })
 
-      it('invokes onFragment for the inline spread on Product', () => {
-        expect(result.extensions?.meta?.['ProductPageContent.products'].onFragmentTrace).toEqual([
+      it('invokes nextFragment for the inline spread on Product', () => {
+        expect(result.extensions?.meta?.['ProductPageContent.products'].nextFragmentTrace).toEqual([
           { fragmentType: 'Product', sourceType: 'Product' },
         ])
       })
 
-      it('invokes onFragment for the named fragment on Product in the order selection', () => {
-        expect(result.extensions?.meta?.['Query.order'].onFragmentTrace).toEqual([
+      it('invokes nextFragment for the named fragment on Product in the order selection', () => {
+        expect(result.extensions?.meta?.['Query.order'].nextFragmentTrace).toEqual([
           { fragmentType: 'Product', sourceType: 'Product' },
         ])
       })

--- a/packages/playground/src/graphql-yoga/resolvers.ts
+++ b/packages/playground/src/graphql-yoga/resolvers.ts
@@ -28,7 +28,7 @@ export const resolvers: Resolver = {
         depth: 2,
       })
       const sequelizeQueryFilters: QueryFilter = {}
-      const orderOnFragmentTrace: { fragmentType: string; sourceType: string }[] = []
+      const orderNextFragmentTrace: { fragmentType: string; sourceType: string }[] = []
 
       lookahead({
         info,
@@ -72,8 +72,8 @@ export const resolvers: Resolver = {
           return nextState
         },
 
-        onFragment({ sourceType, state, type }) {
-          orderOnFragmentTrace.push({ fragmentType: type, sourceType })
+        nextFragment({ sourceType, state, type }) {
+          orderNextFragmentTrace.push({ fragmentType: type, sourceType })
           return state
         },
       })
@@ -88,7 +88,7 @@ export const resolvers: Resolver = {
             ...callInvalidOrderLookaheads(info),
           },
           sequelizeQueryFilters,
-          onFragmentTrace: orderOnFragmentTrace,
+          nextFragmentTrace: orderNextFragmentTrace,
         },
       }
 
@@ -97,7 +97,7 @@ export const resolvers: Resolver = {
 
     page: (_parent, _args, context, info) => {
       const nestedFindOptions: QueryFilter = {}
-      const pageOnFragmentTrace: { fragmentType: string; sourceType: string }[] = []
+      const pageNextFragmentTrace: { fragmentType: string; sourceType: string }[] = []
 
       lookahead({
         info,
@@ -114,8 +114,8 @@ export const resolvers: Resolver = {
           return nextState
         },
 
-        onFragment({ sourceType, state, type }) {
-          pageOnFragmentTrace.push({ fragmentType: type, sourceType })
+        nextFragment({ sourceType, state, type }) {
+          pageNextFragmentTrace.push({ fragmentType: type, sourceType })
           return state
         },
       })
@@ -131,13 +131,13 @@ export const resolvers: Resolver = {
             context.request.metaData = {
               ...context.request.metaData,
               productPageProductsNextStateTag:
-                state.fragmentSeen === true ? 'fromOnFragment' : null,
+                state.fragmentSeen === true ? 'fromNextFragment' : null,
             }
           }
           return state
         },
 
-        onFragment({ state, type }) {
+        nextFragment({ state, type }) {
           if (type === 'ProductPageContent') return { ...state, fragmentSeen: true }
           return state
         },
@@ -155,7 +155,7 @@ export const resolvers: Resolver = {
       // Will be picked up by `useMetaPlugin` to add "extensions.meta" to the final response
       context.request.metaData = {
         ...context.request.metaData,
-        'Query.page': { nestedFindOptions, onFragmentTrace: pageOnFragmentTrace },
+        'Query.page': { nestedFindOptions, nextFragmentTrace: pageNextFragmentTrace },
       }
 
       lookahead({
@@ -182,7 +182,7 @@ export const resolvers: Resolver = {
   ProductPageContent: {
     products: (_parent, _args, context, info) => {
       const sequelizeQueryFilters: QueryFilter = {}
-      const productsOnFragmentTrace: { fragmentType: string; sourceType: string }[] = []
+      const productsNextFragmentTrace: { fragmentType: string; sourceType: string }[] = []
 
       lookahead({
         info,
@@ -197,8 +197,8 @@ export const resolvers: Resolver = {
           return nextState
         },
 
-        onFragment({ sourceType, state, type }) {
-          productsOnFragmentTrace.push({ fragmentType: type, sourceType })
+        nextFragment({ sourceType, state, type }) {
+          productsNextFragmentTrace.push({ fragmentType: type, sourceType })
           return state
         },
       })
@@ -208,7 +208,7 @@ export const resolvers: Resolver = {
         ...context.request.metaData,
         'ProductPageContent.products': {
           sequelizeQueryFilters,
-          onFragmentTrace: productsOnFragmentTrace,
+          nextFragmentTrace: productsNextFragmentTrace,
         },
       }
 

--- a/packages/playground/src/graphql-yoga/resolvers.ts
+++ b/packages/playground/src/graphql-yoga/resolvers.ts
@@ -28,6 +28,7 @@ export const resolvers: Resolver = {
         depth: 2,
       })
       const sequelizeQueryFilters: QueryFilter = {}
+      const orderOnFragmentTrace: { fragmentType: string; sourceType: string }[] = []
 
       lookahead({
         info,
@@ -70,6 +71,11 @@ export const resolvers: Resolver = {
 
           return nextState
         },
+
+        onFragment({ sourceType, state, type }) {
+          orderOnFragmentTrace.push({ fragmentType: type, sourceType })
+          return state
+        },
       })
 
       // Will be picked up by `useMetaPlugin` to add "extensions.meta" to the final response
@@ -82,6 +88,7 @@ export const resolvers: Resolver = {
             ...callInvalidOrderLookaheads(info),
           },
           sequelizeQueryFilters,
+          onFragmentTrace: orderOnFragmentTrace,
         },
       }
 
@@ -90,6 +97,7 @@ export const resolvers: Resolver = {
 
     page: (_parent, _args, context, info) => {
       const nestedFindOptions: QueryFilter = {}
+      const pageOnFragmentTrace: { fragmentType: string; sourceType: string }[] = []
 
       lookahead({
         info,
@@ -105,6 +113,34 @@ export const resolvers: Resolver = {
 
           return nextState
         },
+
+        onFragment({ sourceType, state, type }) {
+          pageOnFragmentTrace.push({ fragmentType: type, sourceType })
+          return state
+        },
+      })
+
+      type FragmentProbeState = { fragmentSeen?: boolean }
+
+      lookahead({
+        info,
+        state: {} as FragmentProbeState,
+
+        next({ state, field, sourceType }) {
+          if (field === 'products' && sourceType === 'ProductPageContent') {
+            context.request.metaData = {
+              ...context.request.metaData,
+              productPageProductsNextStateTag:
+                state.fragmentSeen === true ? 'fromOnFragment' : null,
+            }
+          }
+          return state
+        },
+
+        onFragment({ state, type }) {
+          if (type === 'ProductPageContent') return { ...state, fragmentSeen: true }
+          return state
+        },
       })
 
       // Test case: running a similar check than the one above in order to hit the cache
@@ -119,7 +155,7 @@ export const resolvers: Resolver = {
       // Will be picked up by `useMetaPlugin` to add "extensions.meta" to the final response
       context.request.metaData = {
         ...context.request.metaData,
-        'Query.page': { nestedFindOptions },
+        'Query.page': { nestedFindOptions, onFragmentTrace: pageOnFragmentTrace },
       }
 
       lookahead({
@@ -146,6 +182,7 @@ export const resolvers: Resolver = {
   ProductPageContent: {
     products: (_parent, _args, context, info) => {
       const sequelizeQueryFilters: QueryFilter = {}
+      const productsOnFragmentTrace: { fragmentType: string; sourceType: string }[] = []
 
       lookahead({
         info,
@@ -159,12 +196,20 @@ export const resolvers: Resolver = {
 
           return nextState
         },
+
+        onFragment({ sourceType, state, type }) {
+          productsOnFragmentTrace.push({ fragmentType: type, sourceType })
+          return state
+        },
       })
 
       // Will be picked up by `useMetaPlugin` to add "extensions.meta" to the final response
       context.request.metaData = {
         ...context.request.metaData,
-        'ProductPageContent.products': { sequelizeQueryFilters },
+        'ProductPageContent.products': {
+          sequelizeQueryFilters,
+          onFragmentTrace: productsOnFragmentTrace,
+        },
       }
 
       return mockPage.content.products


### PR DESCRIPTION
## Summary

Adds a **`nextFragment`** handler so lookahead can run on fragment selections (inline fragments and spreads), with the same `state` / return contract as **`next`**. This mirrors how union `... on Type` selections work in operations.

## Why

This is needed for **[GraphQL Gene](https://github.com/accesimpot/graphql-gene) v2**, where polymorphic associations are modeled as **GraphQL unions** and clients often narrow fields with fragments. Lookahead has to observe those fragment steps, not only plain fields.

See the v2 plan: [§ 2.8 Polymorphic associations and GraphQL unions (page blocks)](https://github.com/accesimpot/graphql-gene/blob/main/PLAN_V2.md#28-polymorphic-associations-and-graphql-unions-page-blocks).

## Release

Merging will trigger a new minor release: **1.4.0**