### PR TITLE
ci: skip workflow when actor is acci-semantic-release-token bot

### DIFF
--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -17,3 +17,4 @@ jobs:
             deps
             deps-dev
             README
+            release

--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -17,4 +17,3 @@ jobs:
             deps
             deps-dev
             README
-            release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   should-proceed:
     name: Proceed with the release?
+    if: ${{ github.actor != 'acci-semantic-release-token[bot]' }}
     runs-on: ubuntu-latest
 
     outputs:
@@ -50,7 +51,7 @@ jobs:
 
   release:
     name: Release
-    if: needs.should-proceed.outputs.rebasing-beta == 'false'
+    if: ${{ github.actor != 'acci-semantic-release-token[bot]' && needs.should-proceed.outputs.rebasing-beta == 'false' }}
     needs: [should-proceed]
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns the release workflow with [graphql-gene](https://github.com/accesimpot/graphql-gene): pushes triggered by the npm authentication GitHub App (`acci-semantic-release-token[bot]`) no longer run the release jobs.

## Changes

- **`should-proceed`**: job-level `if: ${{ github.actor != 'acci-semantic-release-token[bot]' }}` so the workflow exits early on those pushes (no checkout / rebasing logic).
- **`release`**: the existing rebasing guard is combined with the same actor check so the release job cannot run for that actor when `should-proceed` runs.

This avoids a feedback loop when semantic-release (or related automation) pushes commits back to `main` / `beta`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0bfe83ab-17dc-4b67-805e-bd233c8ae1e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bfe83ab-17dc-4b67-805e-bd233c8ae1e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

