### PR TITLE
ci: exit should-proceed with git diff status on failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,11 @@ jobs:
           fi
 
           changes=$(git diff HEAD..origin/main --name-only)
+          diff_exit=$?
 
-          if [[ $? != 0 ]]; then
+          if [[ $diff_exit != 0 ]]; then
             echo "rebasing=error" >> $GITHUB_OUTPUT
+            exit "$diff_exit"
           elif [[ $changes ]]; then
             echo "rebasing=false" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Summary

When the rebasing-beta check runs on `beta`, `git diff HEAD..origin/main --name-only` can fail (for example if refs are missing). The step previously wrote `rebasing=error` to `GITHUB_OUTPUT` but did not exit non-zero, so the workflow still appeared successful.

This change saves the diff exit code before any further commands and exits with that code after recording the error output, so the job fails visibly and matches the intent discussed in [graphql-gene#142 (review r3208876316)](https://github.com/accesimpot/graphql-gene/pull/142#discussion_r3208876316).

## Changes

- `.github/workflows/release.yml`: capture `diff_exit` after `git diff`, use it in the condition, and `exit "$diff_exit"` when non-zero.

